### PR TITLE
#99 header overlaping image bug resolved - Fikret Ellek

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -1,10 +1,9 @@
 main {
 	display: flex;
-	flex: 1;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	min-height: 100vh;
+	min-height: calc(100vh - 80px);
 	background-color: #ffffff;
 	font-family: Arial, sans-serif;
 	color: #333333;
@@ -16,8 +15,10 @@ main > div {
 }
 
 .main_page_logo {
-    width: 90%;
-    height: 600px;
+	padding-top: 80px;
+	height: 50dvh;
+	min-height: 300px;
+	width: auto;
 }
 
 .message {


### PR DESCRIPTION
## Naming Rules

Name your PR like this: ISSUENUMBER-TITLE-YOURNAME

## Description

Additional adjustments added that needed for #100 . Padding given to image content to prevent header overlapping. Also the height property value changed from vh to dvh to and header height subtracted from it. So the padding and the calculated height works together to prevent overlaping.

## Related to

Make sure you include the issue number with a hash sign # so Github can link this PR to the right issue, like this:

Fixes #1

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have carefully reviewed my own code
- [ ] I have commented my code
- [ ] I have updated any documentation
